### PR TITLE
Add bert-base-uncased-ldc2012t13_pfeiffer

### DIFF
--- a/adapters/vblagoje/bert-base-uncased-ldc2012t13_pfeiffer.yaml
+++ b/adapters/vblagoje/bert-base-uncased-ldc2012t13_pfeiffer.yaml
@@ -1,0 +1,71 @@
+# Adapter-Hub adapter entry
+# Defines a single adapter entry in Adapter-Hub
+# --------------------
+
+# The name of the author(s) of this adapter.
+author: "Vladimir Blagojevic"
+
+# A bibtex citation of the work related to this adapter.
+citation: |
+  @article{Pfeiffer2020AdapterFusion,
+  author = {Pfeiffer, Jonas and Kamath, Aishwarya and R{\"{u}}ckl{\'{e}}, Andreas and Cho, Kyunghyun and Gurevych, Iryna},
+  journal = {arXiv preprint},
+  title = {{AdapterFusion}:  Non-Destructive Task Composition for Transfer Learning},
+   url       = {https://arxiv.org/pdf/2005.00247.pdf},
+  year = {2020}
+  }
+
+# The string identifier of the adapter architecture (must be available in architecture).
+# Describes the adapter architecture used by this adapter
+config: # TODO: REQUIRED
+  # The name of the adapter config used by this adapter (a short name available in the `architectures` folder).
+  # Example: pfeiffer
+  using: pfeiffer
+
+# The version to be downloaded if no version is explicitly stated.
+default_version: "AdapterFusion"
+
+# A short description of this adapter.
+description: |
+  Pfeiffer Adapter trained on English Dependency Treebank (LDC2012T13) with F1 score of 95.6. See example notebook at https://bit.ly/3klcxfL
+
+# A contact email of the author(s).
+email: "dovlex@gmail.com"
+
+# A list of different versions of this adapter available for download.
+files:
+  - sha1: "e5f3961915f85c56091efde1436e90d3f8a29749"
+    sha256: "a27c2647885266df185792381c3edafa8651ed7c387cd91230b7f633b4106a2b"
+    # Download URL pointing to a zip folder containing the adapter module.
+    url: "https://storage.googleapis.com/models_nlp/AdapterHub/text_task/ldc2012t13/bert-base-uncased/pfeiffer/pos_ldc2012t13.zip"
+    version: "AdapterFusion"
+
+
+# A GitHub handle associated with the author(s).
+github: "vblagoje"
+
+# The hidden size of the model
+hidden_size: 768
+
+# The string identifier of the pre-trained model (by which it is identified at Huggingface).
+# Example: bert-base-uncased
+model_name: "bert-base-uncased"
+
+# The model type.
+# Example: bert
+model_type: bert
+
+# The string identifier of the subtask this adapter belongs to.
+subtask: ldc2012t13
+
+# The string identifier of the task this adapter belongs to.
+task: pos
+
+# A Twitter handle associated with the author(s).
+twitter: "@vladblagoje"
+
+# The type of adapter (one of the options available in `adapter_type`.
+type: "text_task"
+
+# A URL providing more information on this adapter/ the authors/ the organization.
+url: "https://github.com/vblagoje"

--- a/subtasks/text_task/pos_ldc2012t13.yaml
+++ b/subtasks/text_task/pos_ldc2012t13.yaml
@@ -1,0 +1,12 @@
+task: pos
+subtask: ldc2012t13
+displayname: LDC2012T13
+description: |
+   English Web Treebank was developed by the Linguistic Data Consortium (LDC) with funding through a gift from Google Inc. It consists of over 250,000 words of English weblogs, newsgroups, email, reviews and question-answers manually annotated for for sentence- and word-level tokenization, part-of-speech, and syntactic structure.
+url: "https://github.com/UniversalDependencies/UD_English-EWT/"
+citation: |
+  @inproceedings{silveira14gold,
+  year = {2014}, author = {Natalia Silveira and Timothy Dozat and Marie-Catherine de Marneffe and Samuel Bowman and Miriam Connor and John Bauer and Christopher D. Manning},
+  title = {A Gold Standard Dependency Corpus for {E}nglish}, 
+  booktitle = {Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC-2014)}}
+language: english

--- a/tasks/text_task/pos.yaml
+++ b/tasks/text_task/pos.yaml
@@ -1,0 +1,4 @@
+task: pos
+displayname: Part-Of-Speech Tagger
+description: |
+  POS tagging is the process of marking up a word in a text as corresponding to a particular part of speech such as noun, verb, adjective etc.


### PR DESCRIPTION
Adds a POS Tagger trained on LDC2012T13 from https://github.com/UniversalDependencies/UD_English-EWT/ Trained adapter has ~.95 accuracy on test dataset. 

A few things remain to be resolved:

1. I didn't know which organization to use so I just added the adapter to ukp
2. Test colab notebook is [here](https://colab.research.google.com/drive/1KoRQSQVOw-KaCOA1Q3vlQz10YcDguzTs)
3. The notebook has a basic inferencing version and TokenClassificationPipeline version
4. As you know the notebook should be tested by loading adapter from the local filesystem
5. TokenClassificationPipeline does not work until adapter_names is passed to the [model](https://github.com/Adapter-Hub/adapter-transformers/blob/9118a50662d2e7e09817da90bb6b194c604f0c18/src/transformers/pipelines.py#L915)
6. During inferencing, the model returns CLS and SEP tokens as well. See the notebook for details. Is that expected?

