### PR TITLE
Task: Dialect Detection | Subtask: Arabic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 env
 .vscode
+.DS_Store

--- a/adapters/mapmeld/bert-base-arabert-ar-dialect.yaml
+++ b/adapters/mapmeld/bert-base-arabert-ar-dialect.yaml
@@ -1,0 +1,57 @@
+# Adapter-Hub adapter entry
+# Defines a single adapter entry in Adapter-Hub
+# --------------------
+
+# The type of adapter (one of the options available in `adapter_type`.
+type: text_task
+
+# The string identifier of the task this adapter belongs to.
+task: dialect
+
+# The string identifier of the subtask this adapter belongs to.
+subtask: arabic
+
+# The model type.
+# Example: bert
+model_type: bert
+
+# The string identifier of the pre-trained model (by which it is identified at Huggingface).
+# Example: bert-base-uncased
+model_name: aubmindlab/bert-base-arabert
+
+# The name of the author(s) of this adapter.
+author: Nick Doiron
+
+# Describes the adapter architecture used by this adapter
+config:
+  # The name of the adapter config used by this adapter (a short name available in the `architectures` folder).
+  # Example: pfeiffer
+  using: pfeiffer
+default_version: '1'
+
+# A list of different versions of this adapter available for download.
+files:
+- version: '1'
+  url: https://github.com/MonsoonNLP/sanaa-dialect/raw/main/dialect-adapter.zip
+  sha1: 4cdb1891d0e26495422b5408ab921cec559e8d31
+  sha256: 9f974b690fc4df5dfa1cf0cacc4eea46d4912de1b6b057642654a989b15959b0
+
+# (optional) A short description of this adapter.
+description: |
+  Adapter for AraBERT (aubmindlab/bert-base-arabert) trained to classify Arabic by dialect, trained for 3 epochs on samples from University of British Columbia and John Hopkins University.
+
+# (optional) A contact email of the author(s).
+email: ndoiron@mapmeld.com
+
+# (optional) A GitHub handle associated with the author(s).
+github: mapmeld
+
+# (optional) The name of the model class from which this adapter was extracted. This field is mainly intended for adapters with prediction heads.
+# Example: BertModelWithHeads
+model_class: BertModelWithHeads
+
+# (optional) A Twitter handle associated with the author(s).
+twitter: '@mapmeld'
+
+# (optional) A URL providing more information on this adapter/ the authors/ the organization.
+url: https://github.com/MonsoonNLP/sanaa-dialect

--- a/subtasks/text_task/dialect_arabic.yaml
+++ b/subtasks/text_task/dialect_arabic.yaml
@@ -1,0 +1,29 @@
+# Adapter-Hub subtask definition
+# Defines a specific subtask describing the dataset the corresponding modules where trained on.
+# --------------------
+
+# The short identifier of the task this subtask belongs to.
+# Example: nli
+task: dialect
+
+# The short identifier of this subtask.
+# Example: multinli
+subtask: arabic
+
+# A short description of this subtask (max. 500 chars).
+description: |
+  Arabic Dialect Detection classifies text into Modern Standard Arabic (MSA),
+  Egyptian, Maghrebi (northwest Africa), Gulf, and Levantine
+
+
+# The full name of the subtask that should be displayed e.g. on the website.
+# Example: MultiNLI
+displayname: ArabicDialect
+
+# The identifier of the language of the data in this subtask
+language: arabic
+
+# The default evaluation metric of this subtask.
+metric:
+  name: accuracy
+  higher_is_better: true

--- a/tasks/text_task/dialect.yaml
+++ b/tasks/text_task/dialect.yaml
@@ -1,0 +1,5 @@
+task: dialect
+displayname: Dialect Detection
+description: |
+  Dialect detection is a type of classifier which determines the regional origin
+  of text in a language.


### PR DESCRIPTION
This adds a new classification task (dialect detection) and sets up the subtask for Arabic dialects: Gulf, Levantine, Maghrebi, Egyptian, and Modern Standard Arabic (MSA)

I don't include a citation in the subtask yaml. Let me know if I should cite one or multiple papers on this

What can we use to train an adapter? Here's a post that I wrote comparing Arabic dialect datasets: https://medium.com/@mapmeld/embeddings-for-arabic-dialect-classification-1cf84f336044

Dataset options
- Qatar University’s DART 
- University of British Columbia (no Maghrebi labeled data)
- Johns Hopkins University 
- Combination (had best global accuracy)