### PR TITLE
Adding an adapter for formality transfer with GYAFC

### DIFF
--- a/adapters/martiansideofthemoon/xlm-roberta-base_formality_classify_gyafc_pfeiffer.yaml
+++ b/adapters/martiansideofthemoon/xlm-roberta-base_formality_classify_gyafc_pfeiffer.yaml
@@ -1,0 +1,90 @@
+# Adapter-Hub adapter entry
+# Defines a single adapter entry in Adapter-Hub
+# --------------------
+
+# The type of adapter (one of the options available in `adapter_type`.
+type: text_task
+
+# The string identifier of the task this adapter belongs to.
+task: formality_classify
+
+# The string identifier of the subtask this adapter belongs to.
+subtask: gyafc
+
+# The model type.
+# Example: bert
+model_type: xlm-roberta
+
+# The string identifier of the pre-trained model (by which it is identified at Huggingface).
+# Example: bert-base-uncased
+model_name: xlm-roberta-base
+
+# The name of the author(s) of this adapter.
+author: Kalpesh Krishna
+
+# Describes the adapter architecture used by this adapter
+config:
+  # The name of the adapter config used by this adapter (a short name available in the `architectures` folder).
+  # Example: pfeiffer
+  using: pfeiffer
+  non_linearity: relu
+  reduction_factor: 16
+default_version: '1'
+
+# A list of different versions of this adapter available for download.
+files:
+- version: '1'
+  url: http://style.cs.umass.edu/xlm-roberta-base_formality_classify_gyafc_pfeiffer.zip
+  sha1: 074f68696c820fe0dea06cd4fc895ae3c6dc40bc
+  sha256: c0c609aa6cc22520fdcaa560636ca7a36bd716c0593464db945a02367c7cf99f
+citation: |
+  @inproceedings{krishna-etal-2020-reformulating,
+      title = "Reformulating Unsupervised Style Transfer as Paraphrase Generation",
+      author = "Krishna, Kalpesh  and
+        Wieting, John  and
+        Iyyer, Mohit",
+      booktitle = "Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing (EMNLP)",
+      month = nov,
+      year = "2020",
+      address = "Online",
+      publisher = "Association for Computational Linguistics",
+      url = "https://aclanthology.org/2020.emnlp-main.55",
+      doi = "10.18653/v1/2020.emnlp-main.55",
+      pages = "737--762",
+  }
+
+
+# (optional) A list of adapters this adapter is dependent on.
+dependencies:
+    # The key (username/filename_without_ext) of the adapter dependency.
+    # Example: example-org/text_task-sst-bert
+- key: 'en/wiki@ukp'
+    # (optional) A short description how this adapter is dependent.
+  description: 'Trained with this language adapter active, using Stack("en", "gyafc").'
+#   - ...
+
+# (optional) A short description of this adapter.
+description: >
+  This adapter has been trained on the English formality classification GYAFC dataset
+  and tested with other language adapters (like hindi) for zero-shot transfer.
+  Make sure to remove tokenization, lowercase and remove trailing punctuation for
+  best results.
+
+# (optional) A contact email of the author(s).
+email: kalpesh@cs.umass.edu
+
+# (optional) A GitHub handle associated with the author(s).
+github: martiansideofthemoon
+
+# (optional) The name of the model class from which this adapter was extracted. This field is mainly intended for adapters with prediction heads.
+# Example: BertModelWithHeads
+model_class: XLMRobertaModelWithHeads
+
+# (optional) If the adapter has a pre-trained prediction head included.
+prediction_head: true
+
+# (optional) A Twitter handle associated with the author(s).
+twitter: '@kalpeshk2011'
+
+# (optional) A URL providing more information on this adapter/ the authors/ the organization.
+url: https://martiansideofthemoon.github.io/

--- a/subtasks/text_task/formality_classify_gyafc.yaml
+++ b/subtasks/text_task/formality_classify_gyafc.yaml
@@ -1,0 +1,49 @@
+# Adapter-Hub subtask definition
+# Defines a specific subtask describing the dataset the corresponding modules where trained on.
+# --------------------
+
+# The short identifier of the task this subtask belongs to.
+# Example: nli
+task: formality_classify
+
+# The short identifier of this subtask.
+# Example: multinli
+subtask: gyafc
+
+hf_datasets_id: gyafc
+
+# A short description of this subtask (max. 500 chars).
+description: |
+  The Grammarly’s Yahoo Answers Formality Corpus (GYAFC) is the largest dataset for formality
+  classification which contains a total of 110K informal / formal sentence pairs. This is a common
+  benchmark for the text generation task of formality style transfer, and classifiers trained on
+  this benchmark can be used an automatic evaluation for style transfer.
+
+# A bibtex citation of the work related to this subtask.
+citation: |
+  @inproceedings{rao-tetreault-2018-dear,
+      title = "Dear Sir or Madam, May {I} Introduce the {GYAFC} Dataset: Corpus, Benchmarks and Metrics for Formality Style Transfer",
+      author = "Rao, Sudha  and
+        Tetreault, Joel",
+      booktitle = "Proceedings of the 2018 Conference of the North {A}merican Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 1 (Long Papers)",
+      month = jun,
+      year = "2018",
+      address = "New Orleans, Louisiana",
+      publisher = "Association for Computational Linguistics",
+      url = "https://aclanthology.org/N18-1012",
+      doi = "10.18653/v1/N18-1012",
+      pages = "129--140",
+  }
+
+# The full name of the subtask that should be displayed e.g. on the website.
+# Example: MultiNLI
+displayname: Grammarly's Yahoo Answers Formality Corpus (GYAFC)
+
+# The identifier of the language of the data in this subtask
+language: english
+
+# The default evaluation metric of this subtask.
+metric:
+  name: accuracy
+  higher_is_better: true
+url: "https://github.com/raosudha89/GYAFC-corpus"

--- a/tasks/text_task/formality_classify.yaml
+++ b/tasks/text_task/formality_classify.yaml
@@ -2,9 +2,8 @@ task: formality_clasify
 displayname: Formality Classification
 description: |
   The goal of this task is to identify whether a sentence is informal or formal. Informal text
-  tends to use simpler words, compromise spelling grammatical correctness (short forms). It is
-  generally spoken between closely acquainted people during spoken conversations or mediums like
-  online chat. Formal text is more common in literary articles, journalism, legal text, educational
-  material. In conversational text it is more common between strangers, and tends to be on the polite
-  side. Formality transfer is an important text generation task, and formality classification is
-  often used as an evaluation metric for it.
+  tends to use simpler words, compromise spelling (short forms). It is generally spoken between
+  close friends, often on mediums like online chat. Formal text is more common in literary articles,
+  journalism, legal text, educational material. In conversational text it is more common between
+  strangers, and tends to be polite. Formality classifiers are also used to evaluate formality transfer
+  models.

--- a/tasks/text_task/formality_classify.yaml
+++ b/tasks/text_task/formality_classify.yaml
@@ -1,4 +1,4 @@
-task: formality_clasify
+task: formality_classify
 displayname: Formality Classification
 description: |
   The goal of this task is to identify whether a sentence is informal or formal. Informal text

--- a/tasks/text_task/formality_classify.yaml
+++ b/tasks/text_task/formality_classify.yaml
@@ -1,0 +1,10 @@
+task: formality_clasify
+displayname: Formality Classification
+description: |
+  The goal of this task is to identify whether a sentence is informal or formal. Informal text
+  tends to use simpler words, compromise spelling grammatical correctness (short forms). It is
+  generally spoken between closely acquainted people during spoken conversations or mediums like
+  online chat. Formal text is more common in literary articles, journalism, legal text, educational
+  material. In conversational text it is more common between strangers, and tends to be on the polite
+  side. Formality transfer is an important text generation task, and formality classification is
+  often used as an evaluation metric for it.


### PR DESCRIPTION
Trained using the english [GYAFC formality dataset](https://aclanthology.org/N18-1012/), for zero-shot multilingual classification (tested with hindi so far). Best results after lower-casing, detokenizing and removing trailing punctuation from input. To be used with a language adapter like `model.active_adapters = Stack("en", "gyafc")`.