### PR TITLE
Add text classification task 

### DIFF
--- a/tasks/text_task/text-classification.yml
+++ b/tasks/text_task/text-classification.yml
@@ -4,10 +4,10 @@
 
 # The short identifier of this task.
 # Example: sentiment
-task: text-classifcation"
+task: text-classification"
 
 # The full name of the task that should be displayed e.g. on the website.
-displayname: "Text Classifcation"
+displayname: "Text Classification"
 
 # A short description of this task (max. 500 chars).
 description: |

--- a/tasks/text_task/text-classification.yml
+++ b/tasks/text_task/text-classification.yml
@@ -1,0 +1,14 @@
+# Adapter-Hub task definition
+# Defines a broader task/ category that is divided into specific subtasks.
+# --------------------
+
+# The short identifier of this task.
+# Example: sentiment
+task: text-classifcation"
+
+# The full name of the task that should be displayed e.g. on the website.
+displayname: "Text Classifcation"
+
+# A short description of this task (max. 500 chars).
+description: |
+   Text classification describes the task of assigning one or more labels to some text. 


### PR DESCRIPTION
Firstly, thanks for the great library/ecosystem 🤗

This pull request adds a broad task for 'text classification. I plan to push some adapters to the huggingface hub which would most naturally fit under this heading. I noticed some other adapters on the Hub which do text classification are listed under 'other' so apologies if I have missed a reason for not including this task. 

If you prefer to only add a new task when an adapter with that task is uploaded, I can leave this open until I've pushed the adapter to the huggingface hub? 